### PR TITLE
Add trigger on PR for the docker-publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -8,6 +8,11 @@ name: Docker
 on:
   release:
     types: [released]
+  pull_request:
+    branches:
+      - main
+    types: [opened, synchronize, reopened]
+
 
 env:
   # Use docker.io for Docker Hub if empty


### PR DESCRIPTION
The existing workflow has conditions to not actually publish on PR, so we just need to add the trigger.